### PR TITLE
Add a safe way to call MobEffectPacket without causing null deprecated messages

### DIFF
--- a/src/pocketmine/network/protocol/MobEffectPacket.php
+++ b/src/pocketmine/network/protocol/MobEffectPacket.php
@@ -5,16 +5,6 @@ namespace pocketmine\network\protocol;
 
 use pocketmine\utils\Binary;
 
-
-
-
-
-
-
-
-
-
-
 class MobEffectPacket extends DataPacket{
 	const NETWORK_ID = Info::MOB_EFFECT_PACKET;
 
@@ -23,8 +13,8 @@ class MobEffectPacket extends DataPacket{
 	const EVENT_REMOVE = 3;
 
 	public $eid;
-	public $eventId;
-	public $effectId;
+	public $eventId = 0;
+	public $effectId = 0;
 	public $amplifier = 0;
 	public $particles = \true;
 	public $duration = 0;
@@ -34,7 +24,8 @@ class MobEffectPacket extends DataPacket{
 	}
 
 	public function encode(){
-		$this->buffer = \chr(self::NETWORK_ID); $this->offset = 0;;
+		$this->buffer = \chr(self::NETWORK_ID);
+		$this->offset = 0;;
 		$this->buffer .= Binary::writeLong($this->eid);
 		$this->buffer .= \chr($this->eventId);
 		$this->buffer .= \chr($this->effectId);

--- a/src/pocketmine/network/protocol/MobEffectPacket.php
+++ b/src/pocketmine/network/protocol/MobEffectPacket.php
@@ -25,9 +25,9 @@ class MobEffectPacket extends DataPacket{
 	public $eid;
 	public $eventId;
 	public $effectId;
-	public $amplifier;
+	public $amplifier = 0;
 	public $particles = \true;
-	public $duration;
+	public $duration = 0;
 
 	public function decode(){
 


### PR DESCRIPTION
Happened while I tried to remove all effects from a player with `$player->removeAllEffects();`.

` RuntimeException: "chr(): Passing null to parameter #1 ($codepoint) of type int is deprecated" (E_DEPRECATED) in "/src/pocketmine/network/protocol/MobEffectPacket" at line 41`

**Reason:**
When the amplifier (or duration) is not set, it defaults to null. Newer PHP versions (8.1+) throw a deprecation notice (and may throw exceptions in the future).

**Proposed fix:**
Set amplifier and duration to 0 when constructing MobEffectPacket, or use null coalescing in encode(), e.g. chr($this->amplifier ?? 0);.

Tested on:
PHP 8.2